### PR TITLE
Fix Dockerfile for new builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:alpine as builder
 RUN apk add --no-cache curl jq
 RUN mkdir -p /assets
 RUN url=$(curl -s "https://api.github.com/repos/concourse/concourse/releases/latest" \
-    | jq -r '.assets[] | select(.name | test("fly_linux_amd64")) | .browser_download_url') &&\
+    | jq -r '.assets[] | select(.name | test("fly_linux_amd64$")) | .browser_download_url') &&\
     curl -L "$url" -o /assets/fly
 COPY . /go/src/github.com/concourse/concourse-pipeline-resource
 ENV CGO_ENABLED 0


### PR DESCRIPTION
Vito starting releasing (as of 3.13.0) Concourse with sha1 files. This
commit tests for the binary, and not the `fly_linux_amd64.sha1` file.