### PR TITLE
Print output of set pipeline.

### DIFF
--- a/out/command.go
+++ b/out/command.go
@@ -3,6 +3,7 @@ package out
 import (
 	"crypto/md5"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -84,7 +85,10 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 			varsFilepaths = append(varsFilepaths, varFilepath)
 		}
 
-		_, err = c.flyCommand.SetPipeline(p.Name, configFilepath, varsFilepaths, p.Vars)
+		var setOutput []byte
+		setOutput, err = c.flyCommand.SetPipeline(p.Name, configFilepath, varsFilepaths, p.Vars)
+		c.logger.Debugf("pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
+		fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
 		if err != nil {
 			return concourse.OutResponse{}, err
 		}


### PR DESCRIPTION
Fix #37.

Print the output of the set-pipeline command to improve
visibility of the change performed by the resource.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>

I have few questions about this attempt I've made:

1. The solution I'm proposing "pollutes" the output of the tests (although they still return successfully), is it possible to avoid that? I tried returning the output to the "command" but seems a bit complex...

2. The colors of the output of `set-pipeline` are rendered correctly but each line still begins with `` which seems an escape sequence not correctly parsed, any idea where this comes from?