### PR TITLE
Only output the handled pipelines in the metadata of Out.

### DIFF
--- a/out/command.go
+++ b/out/command.go
@@ -122,15 +122,9 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 
 		c.logger.Debugf("Login successful\n")
 
-		pipelines, err := c.flyCommand.Pipelines()
-		if err != nil {
-			return concourse.OutResponse{}, err
-		}
-		c.logger.Debugf("Found pipelines (%s): %+v\n", teamName, pipelines)
-
-		for _, pipelineName := range pipelines {
-			c.logger.Debugf("Getting pipeline: %s\n", pipelineName)
-			outBytes, err := c.flyCommand.GetPipeline(pipelineName)
+		for _, pipeline := range pipelines {
+			c.logger.Debugf("Getting pipeline: %s\n", pipeline.Name)
+			outBytes, err := c.flyCommand.GetPipeline(pipeline.Name)
 			if err != nil {
 				return concourse.OutResponse{}, err
 			}
@@ -139,7 +133,7 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 				"%x",
 				md5.Sum(outBytes),
 			)
-			pipelineVersions[pipelineName] = version
+			pipelineVersions[pipeline.Name] = version
 		}
 	}
 

--- a/out/command_test.go
+++ b/out/command_test.go
@@ -31,7 +31,6 @@ var _ = Describe("Out", func() {
 		pipelines     []concourse.Pipeline
 
 		apiPipelines    []string
-		getPipelinesErr error
 		setPipelinesErr error
 
 		pipelineContents []string
@@ -59,7 +58,6 @@ var _ = Describe("Out", func() {
 		otherTeamName = "some-other-team"
 
 		apiPipelines = []string{"pipeline-1", "pipeline-2", "pipeline-3"}
-		getPipelinesErr = nil
 		setPipelinesErr = nil
 
 		pipelineContents = make([]string, 3)
@@ -159,7 +157,6 @@ pipeline3: foo
 	})
 
 	JustBeforeEach(func() {
-		fakeFlyCommand.PipelinesReturns(apiPipelines, getPipelinesErr)
 		fakeFlyCommand.SetPipelineReturns(nil, setPipelinesErr)
 
 		sanitized := concourse.SanitizedSource(outRequest.Source)
@@ -288,19 +285,6 @@ pipeline3: foo
 			Expect(err).To(HaveOccurred())
 
 			Expect(err).To(Equal(setPipelinesErr))
-		})
-	})
-
-	Context("when getting pipelines returns an error", func() {
-		BeforeEach(func() {
-			getPipelinesErr = fmt.Errorf("some error")
-		})
-
-		It("returns an error", func() {
-			_, err := command.Run(outRequest)
-			Expect(err).To(HaveOccurred())
-
-			Expect(err).To(Equal(getPipelinesErr))
 		})
 	})
 


### PR DESCRIPTION
The metadata of Out now only loops over the pipelines
defined in the Out parameters instead of looping over
all the pipelines of the given team, reducing the
clutter displayed on the job.

The test case for the Pipelines fly command is also
removed from the Out test as it's no longer called.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>