### PR TITLE
Fix bug introduced by #58.

### DIFF
--- a/out/command.go
+++ b/out/command.go
@@ -127,6 +127,9 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 		c.logger.Debugf("Login successful\n")
 
 		for _, pipeline := range pipelines {
+			if pipeline.TeamName != teamName {
+				continue
+			}
 			c.logger.Debugf("Getting pipeline: %s\n", pipeline.Name)
 			outBytes, err := c.flyCommand.GetPipeline(pipeline.Name)
 			if err != nil {


### PR DESCRIPTION
PR #58 introduced a bug where after a pipeline is set
only the pipelines in the configuration are gotten.

However this step was also trying to "get" pipelines
from teams other than the one currently logged in resulting
in an error.

Signed-off-by: Alessandro Degano <alessandro.degano@pix4d.com>