### PR TITLE
Added HideStdout flag for hiding the Fly output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Must be non-nil and non-empty. The structure of the `pipeline` object is as foll
  be exposed after the creation. If it is set to `true`, the command
  `expose-pipeline` will be executed for the specific pipeline.
 
+ - `hide_stdout`: *Optional.* Boolean specifying if the pipeline should
+ hide the fly output showing changes in the pipeline. If it is set to `true`, 
+ the command will not output the fly pipeline changes.
+
 ### dynamic
 
 Resource configuration as above for Check, with the following job configuration:

--- a/concourse/types.go
+++ b/concourse/types.go
@@ -58,6 +58,7 @@ type Pipeline struct {
 	TeamName   string                 `json:"team" yaml:"team"`
 	Unpaused   bool                   `json:"unpaused" yaml:"unpaused"`
 	Exposed    bool                   `json:"exposed" yaml:"exposed"`
+	HideStdout bool                   `json:"hide_stdout" yaml:"hide_stdout"`
 }
 
 type OutResponse struct {

--- a/out/command.go
+++ b/out/command.go
@@ -89,6 +89,8 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 		setOutput, err = c.flyCommand.SetPipeline(p.Name, configFilepath, varsFilepaths, p.Vars)
 
 		if p.HideStdout {
+			fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\nHidden due to HideStdout flag set to \"true\".\n", p.Name)
+		} else {
 			c.logger.Debugf("pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
 			fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
 		}

--- a/out/command.go
+++ b/out/command.go
@@ -87,8 +87,12 @@ func (c *Command) Run(input concourse.OutRequest) (concourse.OutResponse, error)
 
 		var setOutput []byte
 		setOutput, err = c.flyCommand.SetPipeline(p.Name, configFilepath, varsFilepaths, p.Vars)
-		c.logger.Debugf("pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
-		fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
+
+		if p.HideStdout {
+			c.logger.Debugf("pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
+			fmt.Fprintf(os.Stderr, "pipeline '%s' set; output:\n\n%s\n", p.Name, string(setOutput))
+		}
+
 		if err != nil {
 			return concourse.OutResponse{}, err
 		}

--- a/out/command_test.go
+++ b/out/command_test.go
@@ -57,10 +57,10 @@ var _ = Describe("Out", func() {
 		teamName = "main"
 		otherTeamName = "some-other-team"
 
-		apiPipelines = []string{"pipeline-1", "pipeline-2", "pipeline-3"}
+		apiPipelines = []string{"pipeline-1", "pipeline-2", "pipeline-3", "pipeline-4"}
 		setPipelinesErr = nil
 
-		pipelineContents = make([]string, 3)
+		pipelineContents = make([]string, 4)
 
 		pipelineContents[0] = `---
 pipeline1: foo
@@ -72,6 +72,10 @@ pipeline2: foo
 
 		pipelineContents[2] = `---
 pipeline3: foo
+`
+
+		pipelineContents[3] = `---
+pipeline4: foo
 `
 
 		pipelines = []concourse.Pipeline{
@@ -99,6 +103,12 @@ pipeline3: foo
 					"launch-missiles": true,
 				},
 			},
+			{
+				Name:       apiPipelines[3],
+				ConfigFile: "pipeline43.yml",
+				TeamName:   otherTeamName,
+				HideStdout: true,
+			},
 		}
 
 		fakeFlyCommand.GetPipelineStub = func(name string) ([]byte, error) {
@@ -112,6 +122,8 @@ pipeline3: foo
 				return []byte(pipelineContents[1]), nil
 			case apiPipelines[2]:
 				return []byte(pipelineContents[2]), nil
+			case apiPipelines[3]:
+				return []byte(pipelineContents[3]), nil
 			default:
 				Fail("Unexpected invocation of flyCommand.GetPipeline")
 				return nil, nil
@@ -203,6 +215,12 @@ pipeline3: foo
 			if i == 2 {
 				Expect(vars).ToNot(BeNil())
 				Expect(vars["launch-missiles"]).To(BeTrue())
+				Expect(p.HideStdout).To(BeFalse())
+			}
+
+			// the fourth pipeline as hide_stdout: true
+			if i == 3 {
+				Expect(p.HideStdout).To(BeTrue())
 			}
 		}
 	})
@@ -232,7 +250,7 @@ pipeline3: foo
 			_, err := command.Run(outRequest)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(fakeFlyCommand.LoginCallCount()).To(Equal(5))
+			Expect(fakeFlyCommand.LoginCallCount()).To(Equal(6))
 			_, _, _, _, insecure := fakeFlyCommand.LoginArgsForCall(0)
 
 			Expect(insecure).To(BeTrue())


### PR DESCRIPTION
 - fix #66 

Added the ability to hide the Fly stdout specifically for when replacing pipelines. 

This is specifically to prevent secrets being shown, as Fly has no distinct way to avoid this at the moment. 